### PR TITLE
[PRDI-2045] Add custom action to verify that a specific Python version is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# check-python-exists
+
+This is a basic wrapper around the GHA provided `actions/setup-python` that [avoids the issue with requiring `sudo`][1] and having [`/Users/runner/hostedtoolcache` on the self hosted runner][2].
+
+If `is-self-hosted: false` then this falls back to `actions/setup-python` at v5.0.0.
+
+[1]: https://github.com/actions/runner-images/issues/7987
+[2]: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#macos

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is a basic wrapper around the GHA provided `actions/setup-python` that [avoids the issue with requiring `sudo`][1] and having [`/Users/runner/hostedtoolcache` on the self hosted runner][2].
 
-If `is-self-hosted: false` then this falls back to `actions/setup-python` at v5.0.0.
+- If `is-self-hosted: false` then this falls back to `actions/setup-python` at v5.0.0.
+- If `python-version` is provided, that takes precedence over any existing `.python-version` files
+- If you need to point to a different `.python-version` file, pass the path relative to the current working directory to the `python-version-file` parameter.
 
 [1]: https://github.com/actions/runner-images/issues/7987
 [2]: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#macos

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,24 @@
+name: 'Check that Python is available'
+description: 'Verify that the desired Python version is available on the running host.'
+
+inputs:
+  python-version:
+    description: "Exact version of Python."
+  is-self-hosted:
+    description: "Boolean indicating if the runner is self hosted or not, defaults to true."
+    required: false
+    default: 'true'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: GHA setup-python for GH hosted runner
+      if: inputs.is-self-hosted != 'true'
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # 5.0.0
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Check Python exists on path already for self-hosted runner
+      if: inputs.is-self-hosted == 'true'
+      shell: bash
+      run:
+        command -v python${{ inputs.python-version }} > /dev/null 2>&1

--- a/action.yml
+++ b/action.yml
@@ -9,16 +9,32 @@ inputs:
     required: false
     default: 'true'
 
+outputs:
+  python-version:
+    description: "The actual version of Python selected."
+    value: ${{ steps.finalize.outputs.python-version }}
+
 runs:
   using: 'composite'
   steps:
     - name: GHA setup-python for GH hosted runner
+      id: gha-setup-python
       if: inputs.is-self-hosted != 'true'
       uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # 5.0.0
       with:
         python-version: ${{ inputs.python-version }}
     - name: Check Python exists on path already for self-hosted runner
+      id: bcny-check-python
       if: inputs.is-self-hosted == 'true'
       shell: bash
-      run:
+      run: |
         command -v python${{ inputs.python-version }} > /dev/null 2>&1
+    - name: Finalize output
+      id: finalize
+      shell: bash
+      run: |
+        if [[ "${{ inputs.is-self-hosted }}" == "true" ]]; then
+          echo "python-version=${{ inputs.python-version }}" >> $GITHUB_OUTPUT
+        else
+          echo "python-version=${{ steps.gha-setup-pyton.outputs.python-version }}" >> $GITHUB_OUTPUT
+        fi

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,11 @@ description: 'Verify that the desired Python version is available on the running
 
 inputs:
   python-version:
-    description: "Exact version of Python."
+    description: "Exact version of Python. Will override any .python-version file provided either by default or in the python-version-file parameter."
+    default: ''
+  python-version-file:
+    description: "Path to the .python-version file to use to select the desired Python version. This does not support the full flexibility of the .python-version specification but instead only supports a single line in the file with only a single version on that line. Anything else is undefined."
+    default: '.python-version'
   is-self-hosted:
     description: "Boolean indicating if the runner is self hosted or not, defaults to true."
     required: false
@@ -13,6 +17,9 @@ outputs:
   python-version:
     description: "The actual version of Python selected."
     value: ${{ steps.finalize.outputs.python-version }}
+  python-path:
+    description: "The path to the expected Python executable."
+    value: ${{ steps.finalize.outputs.python-path }}
 
 runs:
   using: 'composite'
@@ -28,13 +35,27 @@ runs:
       if: inputs.is-self-hosted == 'true'
       shell: bash
       run: |
-        command -v python${{ inputs.python-version }} > /dev/null 2>&1
+        EXPECTED_VERSION=""
+        if [[ -n "${{ inputs.python-version }}" ]]; then
+          EXPECTED_VERSION="${{ inputs.python-version }}"
+        else
+          if [[ -f "${{ inputs.python-version-file }}" ]]; then
+            EXPECTED_VERSION="$(cat "${{ inputs.python-version-file }}" | cut -d' ' -f1)"
+          fi
+        fi
+
+        command -v python$EXPECTED_VERSION > /dev/null 2>&1
+        EXPECTED_PYTHON_PATH="$(which python${EXPECTED_VERSION})"
+        echo "python-version=${EXPECTED_VERSION}" >> $GITHUB_OUTPUT
+        echo "python-path=${EXPECTED_PYTHON_PATH}" >> $GITHUB_OUTPUT
     - name: Finalize output
       id: finalize
       shell: bash
       run: |
         if [[ "${{ inputs.is-self-hosted }}" == "true" ]]; then
-          echo "python-version=${{ inputs.python-version }}" >> $GITHUB_OUTPUT
+          echo "python-version=${{ steps.bcny-check-python.outputs.python-version }}" >> $GITHUB_OUTPUT
+          echo "python-path=${{ steps.bcny-check-python.outputs.python-path }}" >> $GITHUB_OUTPUT
         else
-          echo "python-version=${{ steps.gha-setup-pyton.outputs.python-version }}" >> $GITHUB_OUTPUT
+          echo "python-version=${{ steps.gha-setup-python.outputs.python-version }}" >> $GITHUB_OUTPUT
+          echo "python-path=${{ steps.gha-setup-python.outputs.python-path }}" >> $GITHUB_OUTPUT
         fi

--- a/action.yml
+++ b/action.yml
@@ -31,31 +31,22 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
     - name: Check Python exists on path already for self-hosted runner
-      id: bcny-check-python
-      if: inputs.is-self-hosted == 'true'
-      shell: bash
-      run: |
-        EXPECTED_VERSION=""
-        if [[ -n "${{ inputs.python-version }}" ]]; then
-          EXPECTED_VERSION="${{ inputs.python-version }}"
-        else
-          if [[ -f "${{ inputs.python-version-file }}" ]]; then
-            EXPECTED_VERSION="$(cat "${{ inputs.python-version-file }}" | cut -d' ' -f1)"
-          fi
-        fi
-
-        command -v python$EXPECTED_VERSION > /dev/null 2>&1
-        EXPECTED_PYTHON_PATH="$(which python${EXPECTED_VERSION})"
-        echo "python-version=${EXPECTED_VERSION}" >> $GITHUB_OUTPUT
-        echo "python-path=${EXPECTED_PYTHON_PATH}" >> $GITHUB_OUTPUT
-    - name: Finalize output
       id: finalize
       shell: bash
       run: |
-        if [[ "${{ inputs.is-self-hosted }}" == "true" ]]; then
+        if [[ "${{ inputs.is-self-hosted }}" != "true" ]]; then
           echo "python-version=${{ steps.bcny-check-python.outputs.python-version }}" >> $GITHUB_OUTPUT
           echo "python-path=${{ steps.bcny-check-python.outputs.python-path }}" >> $GITHUB_OUTPUT
         else
-          echo "python-version=${{ steps.gha-setup-python.outputs.python-version }}" >> $GITHUB_OUTPUT
-          echo "python-path=${{ steps.gha-setup-python.outputs.python-path }}" >> $GITHUB_OUTPUT
+          EXPECTED_VERSION=""
+          if [[ -n "${{ inputs.python-version }}" ]]; then
+            EXPECTED_VERSION="${{ inputs.python-version }}"
+          elif [[ -f "${{ inputs.python-version-file }}" ]]; then
+            EXPECTED_VERSION="$(cat "${{ inputs.python-version-file }}" | cut -d' ' -f1)"
+          fi
+
+          command -v python$EXPECTED_VERSION > /dev/null 2>&1
+          EXPECTED_PYTHON_PATH="$(which python${EXPECTED_VERSION})"
+          echo "python-version=${EXPECTED_VERSION}" >> $GITHUB_OUTPUT
+          echo "python-path=${EXPECTED_PYTHON_PATH}" >> $GITHUB_OUTPUT
         fi

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
       uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # 5.0.0
       with:
         python-version: ${{ inputs.python-version }}
-    - name: Check Python exists on path already for self-hosted runner
+    - name: Check desired Python is available and set outputs
       id: finalize
       shell: bash
       run: |


### PR DESCRIPTION
We need to be able to ensure a desired version of Python is avialable on a runner. For GitHub hosted runners this is accomplished with the `actions/setup-python` action. But for self hosted runners it is a bit trickier.

This approach does the following:
- For a self-hosted runner we simply check if the executable `python<version>` is available
- For a GitHub hosted runner we use the `actions/setup-python` directly
