### PR TITLE
Do not use setup-python on Windows/arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # check-python-exists
 
-This is a basic wrapper around the GHA provided `actions/setup-python` that [avoids the issue with requiring `sudo`][1] and having [`/Users/runner/hostedtoolcache` on the self hosted runner][2].
+This is a basic wrapper around the GHA provided `actions/setup-python` that:
+1. [avoids the issue with requiring `sudo`][1] and having [`/Users/runner/hostedtoolcache` on the self hosted runner][2].
+2. Add support for Windows/ARM64 until [it is fixed upstream][3].
 
 - If `is-self-hosted: false` then this falls back to `actions/setup-python` at v5.0.0.
 - If `python-version` is provided, that takes precedence over any existing `.python-version` files
+- If running on Windows/arm64, uses a hack hardcoded for 3.11.
 - If you need to point to a different `.python-version` file, pass the path relative to the current working directory to the `python-version-file` parameter.
 
 [1]: https://github.com/actions/runner-images/issues/7987
 [2]: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#macos
+[3]: https://github.com/actions/setup-python/issues/715

--- a/action.yml
+++ b/action.yml
@@ -26,16 +26,39 @@ runs:
   steps:
     - name: GHA setup-python for GH hosted runner
       id: gha-setup-python
-      # We want to run this on anything but on self-hosted macs.
-      if: inputs.is-self-hosted == 'false' || runner.os != 'macOS'
+      # We want to run this on anything but on self-hosted macs and Windows
+      # ARM64.
+      if: (inputs.is-self-hosted == 'false' || runner.os != 'macOS') && !(runner.os == 'Windows' && runner.arch == 'ARM64')
       uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # 5.0.0
       with:
         python-version: ${{ inputs.python-version }}
+    - name: "Python for Windows/arm64"
+      id: win-arm64-setup
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      shell: pwsh
+      run: |
+        # Temporary hack until https://github.com/actions/setup-python/issues/715 is
+        # fixed. python win-arm64 has to be added to
+        # https://github.com/actions/python-versions/blob/main/versions-manifest.json
+        if ((Get-Content "${{ inputs.python-version-file }}") -eq "3.11") {
+          $Version = "3.11.9"
+          $Name = "python-${Version}-embed-arm64"
+          curl -O "https://www.python.org/ftp/python/${Version}/${Name}.zip"
+          Expand-Archive "${Name}.zip"
+          echo "${PWD}\${Name}" >> $GITHUB_PATH
+        } else {
+          Write-Host "Please fix hack for python on Windows/ARM64. Maybe https://github.com/actions/setup-python/issues/715 has been fixed."
+          Exit 1
+        }
     - name: Check desired Python is available and set outputs
       id: finalize
       shell: bash
       run: |
-        if [[ "${{ steps.gha-setup-python.outcome }}" == "success" ]]; then
+        if [[ "${{ steps.win-arm64-setup.outcome }}" == "success" ]]; then
+          EXPECTED_VERSION="3"
+          command -v python$EXPECTED_VERSION > /dev/null 2>&1
+          EXPECTED_PYTHON_PATH="$(which python${EXPECTED_VERSION})"
+        elif [[ "${{ steps.gha-setup-python.outcome }}" == "success" ]]; then
           # On macOS, we want something like python3.11, not python3.11.8 like
           # what setup-python above will output.
           # On Windows, we sadly just want python3.
@@ -54,3 +77,4 @@ runs:
         fi
         echo "python-version=${EXPECTED_VERSION}" >> $GITHUB_OUTPUT
         echo "python-path=${EXPECTED_PYTHON_PATH}" >> $GITHUB_OUTPUT
+        echo "Found python${EXPECTED_VERSION} at ${EXPECTED_PYTHON_PATH}"


### PR DESCRIPTION
Sadly, python-3.xx.x-win32-arm64.zip is not present in https://github.com/actions/python-versions/blob/main/versions-manifest.json

As such, setup-python fails to install python on Windows/arm64.

Created a temporary *cough* workaround to install python.

This is tracked upstream as https://github.com/actions/setup-python/issues/715