### PR TITLE
Fix arm64 windows hack when used with `inputs.python-version`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
         # Temporary hack until https://github.com/actions/setup-python/issues/715 is
         # fixed. python win-arm64 has to be added to
         # https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        if (("${{ inputs.python-version }}" -eq "3.11") -or (Test-Path "${{ inputs.python-version-file }}") -and ((Get-Content "${{ inputs.python-version-file }}") -eq "3.11")) {
+        if (("${{ inputs.python-version }}" -eq "3.11") -or ((Test-Path "${{ inputs.python-version-file }}") -and ((Get-Content "${{ inputs.python-version-file }}") -eq "3.11"))) {
           $Version = "3.11.9"
           $Name = "python-${Version}-embed-arm64"
           curl -O "https://www.python.org/ftp/python/${Version}/${Name}.zip"

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
         # Temporary hack until https://github.com/actions/setup-python/issues/715 is
         # fixed. python win-arm64 has to be added to
         # https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        if ((Get-Content "${{ inputs.python-version-file }}") -eq "3.11") {
+        if (("${{ inputs.python-version }}" -eq "3.11") -or (Test-Path "${{ inputs.python-version-file }}") -and ((Get-Content "${{ inputs.python-version-file }}") -eq "3.11")) {
           $Version = "3.11.9"
           $Name = "python-${Version}-embed-arm64"
           curl -O "https://www.python.org/ftp/python/${Version}/${Name}.zip"

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
           $Version = "3.11.9"
           $Name = "python-${Version}-embed-arm64"
           curl -O "https://www.python.org/ftp/python/${Version}/${Name}.zip"
-          Expand-Archive "${Name}.zip"
+          Expand-Archive "${Name}.zip" -Force
           echo "${PWD}\${Name}" >> $GITHUB_PATH
 
           # Some xplat code uses `python3` because that is the executable name on Unix/macOS


### PR DESCRIPTION
We shouldn't need this hack anymore, https://github.com/actions/setup-python/issues/715 is closed and the arm64 versions of python are present in the manifest, but the `setup-python` action seems to run into other issues when installing on a self-hosted Windows arm64 runners.

More investigation is needed, but in the meantime, this PR enables:
* Python 3.11 to be installed on windows arm64 runners just by specifying the correct version as an input parameter
  * previously this would crash as `Get-Content "${{ inputs.python-version-file }}"` would fail with FileNotFound
* Add the `-Force` parameter to the unzip, enabling this action to be run twice on the same machine. Ideally we don't need to run it twice, but `actions/check-python-exists` shouldn't fail if Python was already installed.